### PR TITLE
SKCanvasView support for MAUI Blazor Hybrid and Blazor Server

### DIFF
--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/Internal/DpiWatcherInterop.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/Internal/DpiWatcherInterop.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
@@ -23,7 +23,7 @@ namespace SkiaSharp.Views.Blazor.Internal
 			var interop = Get(js);
 			await interop.ImportAsync();
 			if (callback != null)
-				interop.Subscribe(callback);
+				await interop.SubscribeAsync(callback);
 			return interop;
 		}
 
@@ -36,52 +36,52 @@ namespace SkiaSharp.Views.Blazor.Internal
 			callbackHelper = new FloatFloatActionHelper((o, n) => callbacksEvent?.Invoke(n));
 		}
 
-		protected override void OnDisposingModule() =>
-			Stop();
+		protected override async Task OnDisposingModuleAsync() =>
+			await StopAsync();
 
-		public void Subscribe(Action<double> callback)
+		public async Task SubscribeAsync(Action<double> callback)
 		{
 			var shouldStart = callbacksEvent == null;
 
 			callbacksEvent += callback;
 
 			var dpi = shouldStart
-				? Start()
-				: GetDpi();
+				? await StartAsync()
+				: await GetDpiAsync();
 
 			callback(dpi);
 		}
 
-		public void Unsubscribe(Action<double> callback)
+		public async Task UnsubscribeAsync(Action<double> callback)
 		{
 			callbacksEvent -= callback;
 
 			if (callbacksEvent == null)
-				Stop();
+				await StopAsync();
 		}
 
-		private double Start()
+		private async Task<double> StartAsync()
 		{
 			if (callbackReference != null)
-				return GetDpi();
+				return await GetDpiAsync();
 
 			callbackReference = DotNetObjectReference.Create(callbackHelper);
 
-			return Invoke<double>(StartSymbol, callbackReference);
+			return await Module.InvokeAsync<double>(StartSymbol, callbackReference);
 		}
 
-		private void Stop()
+		private async Task StopAsync()
 		{
 			if (callbackReference == null)
 				return;
 
-			Invoke(StopSymbol);
+			await Module.InvokeVoidAsync(StopSymbol);
 
 			callbackReference?.Dispose();
 			callbackReference = null;
 		}
 
-		public double GetDpi() =>
-			Invoke<double>(GetDpiSymbol);
+		public async Task<double> GetDpiAsync() =>
+			await Module.InvokeAsync<double>(GetDpiSymbol);
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/Internal/SizeWatcherInterop.cs
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/Internal/SizeWatcherInterop.cs
@@ -21,7 +21,7 @@ namespace SkiaSharp.Views.Blazor.Internal
 		{
 			var interop = new SizeWatcherInterop(js, element, callback);
 			await interop.ImportAsync();
-			interop.Start();
+			await interop.StartAsync();
 			return interop;
 		}
 
@@ -33,25 +33,25 @@ namespace SkiaSharp.Views.Blazor.Internal
 			callbackHelper = new FloatFloatActionHelper((x, y) => callback(new SKSize(x, y)));
 		}
 
-		protected override void OnDisposingModule() =>
-			Stop();
+		protected override async Task OnDisposingModuleAsync() =>
+			await StopAsync();
 
-		public void Start()
+		public async Task StartAsync()
 		{
 			if (callbackReference != null)
 				return;
 
 			callbackReference = DotNetObjectReference.Create(callbackHelper);
 
-			Invoke(ObserveSymbol, htmlElement, htmlElementId, callbackReference);
+			await Module.InvokeVoidAsync(ObserveSymbol, htmlElement, htmlElementId, callbackReference);
 		}
 
-		public void Stop()
+		public async Task StopAsync()
 		{
 			if (callbackReference == null)
 				return;
 
-			Invoke(UnobserveSymbol, htmlElementId);
+			await Module.InvokeVoidAsync(UnobserveSymbol, htmlElementId);
 
 			callbackReference?.Dispose();
 			callbackReference = null;

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor.csproj
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/SkiaSharp.Views.Blazor.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.4.2" PrivateAssets="all" />
   </ItemGroup>

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/DpiWatcher.js
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/DpiWatcher.js
@@ -14,14 +14,14 @@ export class DpiWatcher {
         window.clearInterval(DpiWatcher.timerId);
         DpiWatcher.callback = undefined;
     }
-    static update() {
+    static async update() {
         if (!DpiWatcher.callback)
             return;
         const currentDpi = window.devicePixelRatio;
         const lastDpi = DpiWatcher.lastDpi;
         DpiWatcher.lastDpi = currentDpi;
         if (Math.abs(lastDpi - currentDpi) > 0.001) {
-            DpiWatcher.callback.invokeMethod('Invoke', lastDpi, currentDpi);
+            await DpiWatcher.callback.invokeMethodAsync('Invoke', lastDpi, currentDpi);
         }
     }
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/DpiWatcher.ts
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/DpiWatcher.ts
@@ -26,7 +26,7 @@ export class DpiWatcher {
 		DpiWatcher.callback = undefined;
 	}
 
-	static update() {
+	static async update() {
 		if (!DpiWatcher.callback)
 			return;
 
@@ -35,7 +35,7 @@ export class DpiWatcher {
 		DpiWatcher.lastDpi = currentDpi;
 
 		if (Math.abs(lastDpi - currentDpi) > 0.001) {
-			DpiWatcher.callback.invokeMethod('Invoke', lastDpi, currentDpi);
+			await DpiWatcher.callback.invokeMethodAsync('Invoke', lastDpi, currentDpi);
 		}
 	}
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/SizeWatcher.js
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/SizeWatcher.js
@@ -31,11 +31,11 @@ export class SizeWatcher {
             }
         });
     }
-    static invoke(element) {
+    static async invoke(element) {
         const watcherElement = element;
         const instance = watcherElement.SizeWatcher;
         if (!instance || !instance.callback)
             return;
-        return instance.callback.invokeMethod('Invoke', element.clientWidth, element.clientHeight);
+        await instance.callback.invokeMethodAsync('Invoke', element.clientWidth, element.clientHeight);
     }
 }

--- a/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/SizeWatcher.ts
+++ b/source/SkiaSharp.Views/SkiaSharp.Views.Blazor/wwwroot/SizeWatcher.ts
@@ -56,13 +56,13 @@ export class SizeWatcher {
 		});
 	}
 
-	static invoke(element: Element) {
+	static async invoke(element: Element) {
 		const watcherElement = element as SizeWatcherElement;
 		const instance = watcherElement.SizeWatcher;
 
 		if (!instance || !instance.callback)
 			return;
 
-		return instance.callback.invokeMethod('Invoke', element.clientWidth, element.clientHeight);
+		await instance.callback.invokeMethodAsync('Invoke', element.clientWidth, element.clientHeight);
 	}
 }


### PR DESCRIPTION
Using IJSRuntime's async api instead of IJSInProcessRuntime, to allow the canvas component to work in MAUI Hybrid inside a BlazorWebView as well as Blazor Server.

I would like to improve this by adding back IJSInProcessRuntime implementation in the case of WASM runtime environment, which shouldn't be hard.

I have tested this out with MAUI Hybrid Blazor published to Windows, Blazor WASM, and Blazor Server (FireFox on Windows). I plan to test it on every platform before doing a real PR with SkiaSharp.